### PR TITLE
Adding a "remove all" option

### DIFF
--- a/scripts/dockutil
+++ b/scripts/dockutil
@@ -541,6 +541,13 @@ def convertPlist(path, format):
         sys.exit(1)
 
 def removeItem(pl, item_name):
+    if item_name == "all":
+		for dock_item in pl['persistent-apps'][:]:
+			verboseOutput('found', dock_item)
+			pl['persistent-apps'].remove(dock_item)
+		for dock_item in pl['persistent-others'][:]:
+			pl['persistent-others'].remove(dock_item)
+		return True
     for dock_item in pl['persistent-apps']:
         if dock_item['tile-data']['file-label'] == item_name:
             verboseOutput('found', item_name)


### PR DESCRIPTION
Greetings,

I love your script for using with instaDMG.  However, I find it far easier to simply use a blank slate and add the programs you want than to try and modify the standard user template Dock.  So I added an option in the "removeItem" function where you can specify --remove all, and it will iterate through and delete every entry in the Dock.  

It may not be too useful for everyone, but I thought it could potentially be helpful.
