### PR TITLE
Fix problems with unicode file names

### DIFF
--- a/scripts/dockutil
+++ b/scripts/dockutil
@@ -487,6 +487,8 @@ def addItem(pl, add_path, replace_label=None, position=None, before_item=None, a
     if showas == None: showas = 0
     if arrangement == None: arrangement = 2
 
+    #fix problems with unicode file names
+    add_path = unicode(add_path, sys.stdin.encoding)
 
     # set a dock label if one isn't provided
     if label_name == None:


### PR DESCRIPTION
Depending on terminal encoding and/or if you call dockutil with xargs it might screw up writing the plist, since it cant encode the two-/treebyte encoded unicode chars from 'ascii' when the values ar above 0x7F.
