### PR TITLE
enable --remove of multiple dock items at once

### DIFF
--- a/scripts/dockutil
+++ b/scripts/dockutil
@@ -218,7 +218,7 @@ def main():
 
         # for legacy compatibility only
         elif opt == '--hupdock':
-            if arg.lower() == "false" or arg.lower() == "no":
+            if arg.lower() in ("false", "no", "off", "0"):
                 restart_dock = False
 
     # check for an action


### PR DESCRIPTION
I would like to --remove multiple dock items at once; this change implements this such that I do not have to loop dockutil calls (and care about killing the Dock only once) in the shell.
