### PR TITLE
restore Maverics support

### DIFF
--- a/scripts/dockutil
+++ b/scripts/dockutil
@@ -396,12 +396,12 @@ def getOsxVersion():
     """returns a tuple with the (major,minor,revision) numbers"""
     # OS X Yosemite return 10.10, so we will be happy with len(...) == 2, then add 0 for last number
     try:
-        mac_ver = tuple( [ int(n) for n in platform.mac_ver()[0].split('.') ] )
-        assert len(mac_ver) == 2
+        mac_ver = tuple(int(n) for n in platform.mac_ver()[0].split('.'))
+        assert 2 <= len(mac_ver) <= 3
     except Exception as e:
         raise e
     if len(mac_ver) == 2:
-      mac_ver = mac_ver + (0,)
+      mac_ver = mac_ver + (0, )
     return mac_ver
 
 def readPlist(plist_path):


### PR DESCRIPTION
In commit 8e8961ac8a65c2dc8812d6c2ddafc2d56b4831ce, the assertion on
the number of version components was simply changed to support
Yosemite, but the older value of 3 from Maverics would no longer pass
the assertion.  The rest of the code was fine, so we just need to
change the assert.
