### PR TITLE
Corrected documentation typo regarding --view args

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Version 1.1
       --homeloc                                                     overrides the default /Users location for home directories
     
     folder_options:
-      --view [grid|fan|list|automatic]                              stack view option
+      --view [grid|fan|list|auto]                                   stack view option
       --display [folder|stack]                                      how to display a folder's icon
       --sort [name|dateadded|datemodified|datecreated|kind]         sets sorting option for a folder view
     

--- a/scripts/dockutil
+++ b/scripts/dockutil
@@ -52,7 +52,7 @@ plist_location_specifications:
   --homeloc                                                     overrides the default /Users location for home directories
 
 folder_options:
-  --view [grid|fan|list|automatic]                              stack view option
+  --view [grid|fan|list|auto]                                   stack view option
   --display [folder|stack]                                      how to display a folder's icon
   --sort [name|dateadded|datemodified|datecreated|kind]         sets sorting option for a folder view
 


### PR DESCRIPTION
The documentation listed the keyword `automatic` as an acceptable argument to the `--view` flag.
The code has a case for the keyword `auto`, not `automatic`. Updated documentation to reflect this.

Fixes #46 - automatic is an unsupported --view argument