### PR TITLE
Fix handling unicode names in --find, --move and --add  options.

### DIFF
--- a/scripts/dockutil
+++ b/scripts/dockutil
@@ -310,6 +310,8 @@ def main():
                             pass
 
         elif find_label != None: # --find action
+            # correct unicode names handling
+            find_label = find_label.decode('utf-8')
             # since we are only reading the plist, make a copy before converting it to be read
             pl = readPlist(plist_path)
             # set found state
@@ -334,6 +336,8 @@ def main():
                     sys.exit(1)
 
         elif move_label != None: # --move action
+            # correct unicode names handling
+            move_label = move_label.decode('utf-8')
             pl = readPlist(plist_path)
             # check for a position option before processing
             if position is None and before_item is None and after_item is None:
@@ -540,6 +544,7 @@ def addItem(pl, add_path, replace_label=None, position=None, before_item=None, a
     #fix problems with unicode file names
     enc = (sys.stdin.encoding if sys.stdin.encoding else 'UTF-8')
     add_path = unicode(add_path, enc)
+    label_name = label_name.decode('utf-8')
 
     # set a dock label if one isn't provided
     if label_name == None:


### PR DESCRIPTION
Hello.

I've found problem in handling unicode names in --find, --move and --add  options.

For example:
> $ dockutil --find 'Контакты'
> /usr/local/bin/dockutil:317: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
>   if pl[section][item_offset]['tile-data']['file-label'] == find_label:
> Контакты was not found in /Users/nklya/Library/Preferences/com.apple.dock.plist

My environment:
> macOS Sierra 10.12.6
> Python 2.7.10
> locale LANG="ru_RU.UTF-8"

This PR fix these bugs.