### PR TITLE
Embed Info.plist in binary and reference that for version.

### DIFF
--- a/dockutil.xcodeproj/project.pbxproj
+++ b/dockutil.xcodeproj/project.pbxproj
@@ -31,7 +31,6 @@
 
 /* Begin PBXFileReference section */
 		4A0940A327BB88A800A1F9D7 /* DockUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockUtil.swift; sourceTree = "<group>"; };
-		4A0940A727C49DD000A1F9D7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4AE244C0249C586900836787 /* dockutil */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = dockutil; sourceTree = BUILT_PRODUCTS_DIR; };
 		4AE244C3249C586900836787 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		4AE244D1249C5CF700836787 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -39,6 +38,7 @@
 		4AE244D5249C5CF700836787 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4AE244D9249C5DC000836787 /* Dock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dock.swift; sourceTree = "<group>"; };
 		4AE244DF249C637900836787 /* DockTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockTile.swift; sourceTree = "<group>"; };
+		94F771CE27C81B5C00393378 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,7 +85,7 @@
 				4A0940A327BB88A800A1F9D7 /* DockUtil.swift */,
 				4AE244D9249C5DC000836787 /* Dock.swift */,
 				4AE244DF249C637900836787 /* DockTile.swift */,
-				4A0940A727C49DD000A1F9D7 /* Info.plist */,
+				94F771CE27C81B5C00393378 /* Info.plist */,
 			);
 			path = dockutil;
 			sourceTree = "<group>";
@@ -339,6 +339,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
 				DEVELOPMENT_TEAM = Z5J8CJBUWC;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/dockutil/Info.plist";
@@ -354,6 +355,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
+				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
 				DEVELOPMENT_TEAM = Z5J8CJBUWC;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/dockutil/Info.plist";

--- a/dockutil.xcodeproj/project.pbxproj
+++ b/dockutil.xcodeproj/project.pbxproj
@@ -345,6 +345,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/dockutil/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = "3.0.0-beta.2";
+				PRODUCT_BUNDLE_IDENTIFIER = dockutil.cli.tool;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 			};

--- a/dockutil/DockUtil.swift
+++ b/dockutil/DockUtil.swift
@@ -10,7 +10,7 @@ import Foundation
 import ArgumentParser
 import Darwin
 
-let VERSION = "3.0.0-beta.2"
+let VERSION = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as! String
 var gv = 0 // Global verbosity
 
 struct DockAdditionOptions {

--- a/dockutil/Info.plist
+++ b/dockutil/Info.plist
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<!--
-   Info.plist
-   dockutil
-
-   Created by Kyle Crawford on 2/21/22.
-   Copyright (c) 2022 KC. All rights reserved.
--->
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
 </plist>


### PR DESCRIPTION
This will embed the Info.plist into the binary itself, so that version can be maintained in the Xcode project's General > Version field rather than the swift file itself. This should cut down on accidental updates without modifying the version.

You can test that the Info.plist is successfully embedded in the binary with `otool -P /path/to/dockutil` or just test using the `--version` flag as it still works.

@kcrawford Thanks for the awesome work on this tool, it has been an asset of ours and the MacAdmins community for years.