### PR TITLE
#120 Bad Item label after add to dock

### DIFF
--- a/dockutil/Dock.swift
+++ b/dockutil/Dock.swift
@@ -224,7 +224,12 @@ class Dock {
             if opts.tileType == .url {
                 opts.label = opts.path
             } else {
+               if (opts.path.hasSuffix(".app")) {
                 opts.label = URL(fileURLWithPath: opts.path).deletingPathExtension().lastPathComponent
+                  }
+               else {
+                  opts.label = URL(fileURLWithPath: opts.path).lastPathComponent
+               }
             }
         }
         


### PR DESCRIPTION
Fix bug when folder contains "." in folder name.
Remove extension only if it is application.