### PR TITLE
Adds --label command switch to spacer tile entries

### DIFF
--- a/Sources/DockUtil/Dock.swift
+++ b/Sources/DockUtil/Dock.swift
@@ -248,7 +248,10 @@ class Dock {
                     opts.label = URL(fileURLWithPath: opts.path).deletingPathExtension().lastPathComponent
                 } else {
                     opts.label = URL(fileURLWithPath: opts.path).lastPathComponent
-               }
+                }
+            }
+            if opts.tileType.rawValue == "spacer-tile" || opts.tileType.rawValue == "small-spacer-tile" || opts.tileType.rawValue == "flex-spacer-tile" {
+                opts.label = "spacer"+String(Int.random(in: 1..<99))
             }
         }
         
@@ -318,7 +321,9 @@ class Dock {
         case .spacer,.smallSpacer,.flexSpacer:
             itemDictionary = [
                 "GUID": newGUID as AnyObject,
-                "tile-data": [String:AnyObject]() as AnyObject,
+                "tile-data": [
+                    "label": opts.label
+                    ]  as AnyObject,
                 "tile-type": opts.tileType.rawValue as AnyObject
             ]
         }


### PR DESCRIPTION
This adds the --label command switch to spacer tile entries.

This allows them to be found, moved and removed like regular entries while still being removed by the --remove spacer-tiles command.

If no --label is used during creation of spacer tile, a default label will be added in format spacer+(random number from 1-99) for example spacer56.

This should resolve issue #161